### PR TITLE
Export version-related environment variables.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,14 +30,22 @@ install -m 0664 include/pvxs/* ${PREFIX}/include/pvxs/
 install -m 0664 dbd/* ${PREFIX}/pvxs/dbd
 install -m 0664 db/* ${PREFIX}/pvxs/db
 
+IFS='.' read -r MAJOR MINOR MAINTENANCE <<< "$PKG_VERSION"
+
 mkdir -p $PREFIX/etc/conda/activate.d
 cat <<EOF > $PREFIX/etc/conda/activate.d/pvxs_activate.sh
 export PVXS="${PREFIX}/pvxs/"
+export PVXS_MAJOR_VERSION="${MAJOR}"
+export PVXS_MINOR_VERSION="${MINOR}"
+export PVXS_MAINTENANCE_VERSION="${MAINTENANCE}"
 EOF
 
 mkdir -p $PREFIX/etc/conda/deactivate.d
 cat <<EOF > $PREFIX/etc/conda/deactivate.d/pvxs_deactivate.sh
 unset PVXS
+unset PVXS_MAJOR_VERSION
+unset PVXS_MINOR_VERSION
+unset PVXS_MAINTENANCE_VERSION
 EOF
 
 if [[ "$target_platform" == osx* ]]; then

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,7 +15,7 @@ source:
     - 0002-Workaround-cfg-include-bug.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This adds support for exporting the PVXS version components during environment activation. The variables follow the definitions used in the PVXS module: https://github.com/epics-base/pvxs/blob/master/configure/CONFIG_PVXS_VERSION.
